### PR TITLE
Ib-ISN functions should take daraframe parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,69 +30,46 @@ pip install ibisn
 
 ## Usage
 
-### Data preprocessing and imputation
+1. Data preprocessing and imputation
 
 ```python
+import pandas as pd
 import ibisn
 
-# returns 
-ibisn.preprocess_gtf(gtf)
+snps = pd.read_csv("snp_dataset.csv")
+snp_meta = pd.read_csv("snp_metadata.csv")
+interact = pd.read_csv("interactome_interactions.csv")
+gtf = pd.read_csv("human_genes.csv")
 
 # returns 
-ibisn.preprocess_snp(snp_info)
+gene_info = ibisn.preprocess_gtf(gtf)
 
 # returns 
-ibisn.impute(snps)
+ibisn.preprocess_snp(snp_meta)
 
 # returns 
-ibisn.impute_chunked(snps, chunks)
-
+snps = ibisn.impute(snps)
 ```
 
-### Mapping
+2. Mapping
 
 ```python
-import ibisn
-
 # returns 
-ibisn.positional_mapping(snp_info, gene_info, neighborhood)
-
+ibisn.positional_mapping(snp_meta, gene_info, neighborhood=5)
 ```
-### Features mapping and interaction
+
+3. Features mapping and interaction
 
 ```python
-import ibisn
-
 # returns 
-ibisn.positional_mapping(snp_info, gene_info, neighborhood)
-
-# returns 
-ibisn.snp_interaction(interact, gene_info, snp_info)
-isn_calculation_all(df, interact_snp, interact_gene, metric, pool)
+(interact_snp, interact_gene) = ibisn.snp_interaction(interact, gene_info, snp_info)
 ```
-### Individual Specific Network (ISN) computation
+
+4. Individual Specific Network (ISN) computation
 
 ```python
-import ibisn
-
-# returns 
-ibisn.isn_calculation_all(df, interact_snp, interact_gene, metric, pool)
+isn = ibisn.isn_calculation_all(df, interact_snp, interact_gene, "spearman", "max")
 ```
-
-TO BE MODIFIED LATER ON
-# ## Data calling
-
-gene_info = preprocess_gtf(gtf)
-
-snp_info = preprocess_snp(snp_info)
-
-df = impute(df)
-
-tmp = positional_mapping(snp_info, gene_info, neighborhood=0)
-
-interact_snp, interact_sub = snp_interaction(interact, gene_info, snp_info)
-
-df_isn = isn_calculation_all(df, interact_snp, interact_sub, "spearman", "max")
 
 For more examples, please refer to the _Documentation_.
 

--- a/ib_isn/ibisn.py
+++ b/ib_isn/ibisn.py
@@ -19,11 +19,8 @@ import marshal
 
 # ## Preprocessing
 
-def preprocess_gtf(gtf):
-    
-    # list of genes in the human genome with chr:start-stop
-    gtf = pd.read_csv(filename)
 
+def preprocess_gtf(gtf):
     gtf[["ENSEMBL_ID", "B"]] = gtf[8].str.split(";", 1, expand=True)
     gtf[["VERSION", "D"]] = gtf["B"].str.split(";", 1, expand=True)
     gtf[["NAME", "E"]] = gtf["D"].str.split(";", 1, expand=True)
@@ -48,18 +45,17 @@ def preprocess_gtf(gtf):
 
     return gene_info
 
-def preprocess_snp(snp_info):
-    
-    # snp info: name, chr, position
-    snp_info = pd.read_csv(filename)
 
+def preprocess_snp(snp_info):
     snp_info = snp_info.set_index("name")
     snp_info = snp_info[snp_info.chr != "23"]
     snp_info = snp_info[snp_info.chr != "25"]
     snp_info = snp_info[snp_info.chr != "26"]
     return snp_info
 
+
 # ### Imputation
+
 
 def impute(snps):
     for j in range(snps.shape[1]):
@@ -75,6 +71,7 @@ def impute(snps):
         snps.iloc[miss, j] = mod
     return snps
 
+
 def impute_chunked(snps, chunks):
     column_index = snps.columns.tolist()
     chunk_idx = np.array_split(np.arange(snps.shape[1]), chunks)
@@ -84,7 +81,9 @@ def impute_chunked(snps, chunks):
     df.columns = column_index
     return df
 
+
 # ## Mapping
+
 
 def positional_mapping(snp_info, gene_info, neighborhood):
 
@@ -126,7 +125,9 @@ def positional_mapping(snp_info, gene_info, neighborhood):
 
     return mapping
 
+
 # ## Interactions
+
 
 def snp_interaction(interact, gene_info, snp_info):
 
@@ -141,12 +142,9 @@ def snp_interaction(interact, gene_info, snp_info):
                  where the 2 columns are the chromosome and position of every SNP.
     :return: a list of tuples whose elements are 2 lists.
     """
-    
-    # tuple: interactome interactions
-    interact = pd.read_csv(filename)
 
     mapping = positional_mapping(snp_info, gene_info, 2000)
-    
+
     interact_sub = []
     interact_snp = []
     interact = interact.to_records(index=False)
@@ -159,7 +157,9 @@ def snp_interaction(interact, gene_info, snp_info):
 
     return (interact_snp, interact_sub)
 
+
 # ## Metrics
+
 
 def pooling(scores, pool):
 
@@ -179,6 +179,7 @@ def pooling(scores, pool):
     else:
         # sys.exit('Wrong input for pooling method!')
         raise ValueError("Wrong input for pooling method!")
+
 
 def compute_metric(X, Y, method, pool):
 
@@ -216,7 +217,9 @@ def compute_metric(X, Y, method, pool):
         raise ValueError("Wrong input for metric!")
     return score
 
+
 # ## ISNs calculation
+
 
 def isn_calculation_all(df, interact_snp, interact_gene, metric, pool):
     import numpy as np


### PR DESCRIPTION
We can take either filename or dataframe parameters. By taking dataframe parameters we remain flexible for users to decide how they compute the input dataframes (e.g. they may not have files).

This change also updates the typical usage scenario documented in the README to reflect my understanding of the API.